### PR TITLE
change nullability to fix tray builder error

### DIFF
--- a/lib/src/view/components/tray/animated_tray.dart
+++ b/lib/src/view/components/tray/animated_tray.dart
@@ -47,7 +47,7 @@ abstract class AnimatedTrayState<T extends AnimatedTray> extends State<T> {
   @mustCallSuper
   void didChangeDependencies() {
     if (_manager == null) {
-      _position = TrayPositionProvider.of(context)!.index;
+      _position = TrayPositionProvider.of(context)?.index;
       _manager = TrayAnimationManager.of(context);
       _manager!.addListener(_animationListener, _position);
     }


### PR DESCRIPTION
change nullability to fix tray builder null check exception that happens when trying to wrap tray builder with any widget